### PR TITLE
Add session profile creation front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Visit `http://localhost:5000` in your browser. Use the links to swipe through jobs or candidates.
+Visit `http://localhost:8000` in your browser. Create a job or employee profile on the front page, then swipe through the opposite list.

--- a/templates/candidate.html
+++ b/templates/candidate.html
@@ -1,5 +1,8 @@
 <!doctype html>
 <title>Candidate Swipe</title>
+{% if job %}
+<p>Swiping for {{ job.title }} - {{ job.company }}</p>
+{% endif %}
 <h2>{{ candidate.name }}</h2>
 <p><strong>Skills:</strong> {{ candidate.skills }}</p>
 <p><strong>Experience:</strong> {{ candidate.experience }}</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,19 @@
 <!doctype html>
 <title>Job Finder</title>
 <h1>Welcome to Job Finder</h1>
-<p><a href="{{ url_for('swipe_jobs') }}">Swipe Jobs</a></p>
-<p><a href="{{ url_for('swipe_candidates') }}">Swipe Candidates</a></p>
+
+<h2>Create a Job</h2>
+<form action="{{ url_for('create_job') }}" method="post">
+  <label>Title: <input type="text" name="title" /></label><br />
+  <label>Company: <input type="text" name="company" /></label><br />
+  <label>Description: <input type="text" name="description" /></label><br />
+  <button type="submit">Start Swiping Candidates</button>
+</form>
+
+<h2>Create an Employee</h2>
+<form action="{{ url_for('create_employee') }}" method="post">
+  <label>Name: <input type="text" name="name" /></label><br />
+  <label>Skills: <input type="text" name="skills" /></label><br />
+  <label>Experience: <input type="text" name="experience" /></label><br />
+  <button type="submit">Start Swiping Jobs</button>
+</form>

--- a/templates/job.html
+++ b/templates/job.html
@@ -1,5 +1,8 @@
 <!doctype html>
 <title>Job Swipe</title>
+{% if employee %}
+<p>Swiping as {{ employee.name }}</p>
+{% endif %}
 <h2>{{ job.title }} - {{ job.company }}</h2>
 <p>{{ job.description }}</p>
 <form action="{{ url_for('handle_job_action', action='like') }}" method="post">


### PR DESCRIPTION
## Summary
- Add routes and session logic to create job or employee profiles before swiping
- Introduce forms on the home page to set up a job or employee for the session
- Display session profile info while swiping and update README

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_689dba74af4c8321bdc0bbd307871fc0