### PR TITLE
Add profile persistence and match tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Job Finder
 
-A simple swiping web app built with Flask. It lets you swipe through jobs or potential employees using in-memory sample data.
+A simple swiping web app built with Flask. It lets you swipe through jobs or potential employees. Profiles are stored in `data.json` so new accounts and swipe results persist across sessions.
 
 ## Setup
 
@@ -17,3 +17,4 @@ python app.py
 ```
 
 Visit `http://localhost:8000` in your browser. Create a job or employee profile on the front page, then swipe through the opposite list.
+Existing accounts can be revisited from the home page, and mutual likes appear on the Matches page for review.

--- a/app.py
+++ b/app.py
@@ -1,86 +1,219 @@
 from flask import Flask, render_template, session, redirect, url_for, request
 from models import Job, Employee
+from dataclasses import asdict
+import json
+import os
 
 app = Flask(__name__)
 app.secret_key = "dev"
 
-jobs = [
-    Job(1, "Backend Developer", "TechCorp", "Work on APIs and services."),
-    Job(2, "Frontend Developer", "Webify", "Build engaging user interfaces."),
-    Job(3, "Data Scientist", "DataMagic", "Analyze and model complex datasets."),
-    Job(4, "DevOps Engineer", "CloudNine", "Manage infrastructure and deployments."),
-    Job(5, "Product Manager", "InnoSoft", "Guide product vision and execution."),
-]
+DATA_FILE = "data.json"
 
-employees = [
-    Employee(1, "Alice", "Python, Flask", "3 years at StartUp"),
-    Employee(2, "Bob", "JavaScript, React", "2 years freelancing"),
-    Employee(3, "Carol", "Data analysis, SQL", "4 years at FinanceCo"),
-    Employee(4, "Dave", "DevOps, Docker", "5 years at CloudCo"),
-    Employee(5, "Eve", "Product strategy, Agile", "6 years at BigCorp"),
-]
+
+def load_data():
+    """Load persisted jobs, employees and swipe data."""
+    global jobs, employees, job_likes, job_dislikes, employee_likes, employee_dislikes, matches
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE) as f:
+            data = json.load(f)
+        jobs = [Job(**j) for j in data.get("jobs", [])]
+        employees = [Employee(**e) for e in data.get("employees", [])]
+        likes = data.get("likes", {})
+        job_likes = {int(k): set(v) for k, v in likes.get("job_likes", {}).items()}
+        job_dislikes = {int(k): set(v) for k, v in likes.get("job_dislikes", {}).items()}
+        employee_likes = {int(k): set(v) for k, v in likes.get("employee_likes", {}).items()}
+        employee_dislikes = {int(k): set(v) for k, v in likes.get("employee_dislikes", {}).items()}
+        matches = set(tuple(m) for m in data.get("matches", []))
+    else:
+        jobs = [
+            Job(1, "Backend Developer", "TechCorp", "Work on APIs and services."),
+            Job(2, "Frontend Developer", "Webify", "Build engaging user interfaces."),
+            Job(3, "Data Scientist", "DataMagic", "Analyze and model complex datasets."),
+            Job(4, "DevOps Engineer", "CloudNine", "Manage infrastructure and deployments."),
+            Job(5, "Product Manager", "InnoSoft", "Guide product vision and execution."),
+        ]
+
+        employees = [
+            Employee(1, "Alice", "Python, Flask", "3 years at StartUp"),
+            Employee(2, "Bob", "JavaScript, React", "2 years freelancing"),
+            Employee(3, "Carol", "Data analysis, SQL", "4 years at FinanceCo"),
+            Employee(4, "Dave", "DevOps, Docker", "5 years at CloudCo"),
+            Employee(5, "Eve", "Product strategy, Agile", "6 years at BigCorp"),
+        ]
+
+        job_likes = {}
+        job_dislikes = {}
+        employee_likes = {}
+        employee_dislikes = {}
+        matches = set()
+        save_data()
+
+
+def save_data():
+    data = {
+        "jobs": [asdict(j) for j in jobs],
+        "employees": [asdict(e) for e in employees],
+        "likes": {
+            "job_likes": {k: list(v) for k, v in job_likes.items()},
+            "job_dislikes": {k: list(v) for k, v in job_dislikes.items()},
+            "employee_likes": {k: list(v) for k, v in employee_likes.items()},
+            "employee_dislikes": {k: list(v) for k, v in employee_dislikes.items()},
+        },
+        "matches": [list(m) for m in matches],
+    }
+    with open(DATA_FILE, "w") as f:
+        json.dump(data, f)
+
+
+# initialise data
+load_data()
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    return render_template("index.html", jobs=jobs, employees=employees)
 
 
 @app.route("/create_job", methods=["POST"])
 def create_job():
-    job_data = {
-        "title": request.form.get("title"),
-        "company": request.form.get("company"),
-        "description": request.form.get("description"),
-    }
-    session["my_job"] = job_data
+    next_id = max([j.id for j in jobs], default=0) + 1
+    job = Job(
+        next_id,
+        request.form.get("title"),
+        request.form.get("company"),
+        request.form.get("description"),
+    )
+    jobs.append(job)
+    session["my_job_id"] = job.id
     session["candidate_index"] = 0
+    save_data()
     return redirect(url_for("swipe_candidates"))
 
 
 @app.route("/create_employee", methods=["POST"])
 def create_employee():
-    employee_data = {
-        "name": request.form.get("name"),
-        "skills": request.form.get("skills"),
-        "experience": request.form.get("experience"),
-    }
-    session["my_employee"] = employee_data
+    next_id = max([e.id for e in employees], default=0) + 1
+    employee = Employee(
+        next_id,
+        request.form.get("name"),
+        request.form.get("skills"),
+        request.form.get("experience"),
+    )
+    employees.append(employee)
+    session["my_employee_id"] = employee.id
+    session["job_index"] = 0
+    save_data()
+    return redirect(url_for("swipe_jobs"))
+
+
+@app.route("/login_job/<int:job_id>")
+def login_job(job_id):
+    session["my_job_id"] = job_id
+    session["candidate_index"] = 0
+    return redirect(url_for("swipe_candidates"))
+
+
+@app.route("/login_employee/<int:employee_id>")
+def login_employee(employee_id):
+    session["my_employee_id"] = employee_id
     session["job_index"] = 0
     return redirect(url_for("swipe_jobs"))
 
 @app.route("/jobs")
 def swipe_jobs():
-    if "my_employee" not in session:
+    if "my_employee_id" not in session:
         return redirect(url_for("index"))
+    emp_id = session["my_employee_id"]
+    liked = employee_likes.get(emp_id, set())
+    disliked = employee_dislikes.get(emp_id, set())
+    available_jobs = [j for j in jobs if j.id not in liked and j.id not in disliked]
     index = session.get("job_index", 0)
-    if index >= len(jobs):
-        return render_template("done.html", target="jobs")
-    job = jobs[index]
-    return render_template("job.html", job=job, employee=session.get("my_employee"))
+    if index >= len(available_jobs):
+        return render_template("done.html", target="jobs", employee=_get_employee(emp_id))
+    job = available_jobs[index]
+    return render_template("job.html", job=job, employee=_get_employee(emp_id))
 
 @app.route("/jobs/<action>", methods=["POST"])
 def handle_job_action(action):
+    if "my_employee_id" not in session:
+        return redirect(url_for("index"))
+    emp_id = session["my_employee_id"]
+    liked = employee_likes.get(emp_id, set())
+    disliked = employee_dislikes.get(emp_id, set())
+    available_jobs = [j for j in jobs if j.id not in liked and j.id not in disliked]
     index = session.get("job_index", 0)
+    if index >= len(available_jobs):
+        return redirect(url_for("swipe_jobs"))
+    job = available_jobs[index]
+    job_id = job.id
+    if action == "like":
+        employee_likes.setdefault(emp_id, set()).add(job_id)
+        if emp_id in job_likes.get(job_id, set()):
+            matches.add((job_id, emp_id))
+    else:
+        employee_dislikes.setdefault(emp_id, set()).add(job_id)
     session["job_index"] = index + 1
+    save_data()
     return redirect(url_for("swipe_jobs"))
 
 @app.route("/candidates")
 def swipe_candidates():
-    if "my_job" not in session:
+    if "my_job_id" not in session:
         return redirect(url_for("index"))
+    job_id = session["my_job_id"]
+    liked = job_likes.get(job_id, set())
+    disliked = job_dislikes.get(job_id, set())
+    available_candidates = [e for e in employees if e.id not in liked and e.id not in disliked]
     index = session.get("candidate_index", 0)
-    if index >= len(employees):
-        return render_template("done.html", target="candidates")
-    candidate = employees[index]
-    return render_template(
-        "candidate.html", candidate=candidate, job=session.get("my_job")
-    )
+    if index >= len(available_candidates):
+        return render_template("done.html", target="candidates", job=_get_job(job_id))
+    candidate = available_candidates[index]
+    return render_template("candidate.html", candidate=candidate, job=_get_job(job_id))
 
 @app.route("/candidates/<action>", methods=["POST"])
 def handle_candidate_action(action):
+    if "my_job_id" not in session:
+        return redirect(url_for("index"))
+    job_id = session["my_job_id"]
+    liked = job_likes.get(job_id, set())
+    disliked = job_dislikes.get(job_id, set())
+    available_candidates = [e for e in employees if e.id not in liked and e.id not in disliked]
     index = session.get("candidate_index", 0)
+    if index >= len(available_candidates):
+        return redirect(url_for("swipe_candidates"))
+    candidate = available_candidates[index]
+    emp_id = candidate.id
+    if action == "like":
+        job_likes.setdefault(job_id, set()).add(emp_id)
+        if job_id in employee_likes.get(emp_id, set()):
+            matches.add((job_id, emp_id))
+    else:
+        job_dislikes.setdefault(job_id, set()).add(emp_id)
     session["candidate_index"] = index + 1
+    save_data()
     return redirect(url_for("swipe_candidates"))
+
+
+@app.route("/matches")
+def matches_view():
+    if "my_job_id" in session:
+        job_id = session["my_job_id"]
+        matched_emp_ids = [e for j, e in matches if j == job_id]
+        matched_emps = [e for e in employees if e.id in matched_emp_ids]
+        return render_template("matches.html", my_job=_get_job(job_id), matches=matched_emps)
+    if "my_employee_id" in session:
+        emp_id = session["my_employee_id"]
+        matched_job_ids = [j for j, e in matches if e == emp_id]
+        matched_jobs = [j for j in jobs if j.id in matched_job_ids]
+        return render_template("matches.html", my_employee=_get_employee(emp_id), matches=matched_jobs)
+    return redirect(url_for("index"))
+
+
+def _get_job(job_id):
+    return next((j for j in jobs if j.id == job_id), None)
+
+
+def _get_employee(emp_id):
+    return next((e for e in employees if e.id == emp_id), None)
 
 if __name__ == "__main__":
     app.run(debug=True, port=8000)

--- a/data.json
+++ b/data.json
@@ -1,0 +1,23 @@
+{
+  "jobs": [
+    {"id": 1, "title": "Backend Developer", "company": "TechCorp", "description": "Work on APIs and services."},
+    {"id": 2, "title": "Frontend Developer", "company": "Webify", "description": "Build engaging user interfaces."},
+    {"id": 3, "title": "Data Scientist", "company": "DataMagic", "description": "Analyze and model complex datasets."},
+    {"id": 4, "title": "DevOps Engineer", "company": "CloudNine", "description": "Manage infrastructure and deployments."},
+    {"id": 5, "title": "Product Manager", "company": "InnoSoft", "description": "Guide product vision and execution."}
+  ],
+  "employees": [
+    {"id": 1, "name": "Alice", "skills": "Python, Flask", "experience": "3 years at StartUp"},
+    {"id": 2, "name": "Bob", "skills": "JavaScript, React", "experience": "2 years freelancing"},
+    {"id": 3, "name": "Carol", "skills": "Data analysis, SQL", "experience": "4 years at FinanceCo"},
+    {"id": 4, "name": "Dave", "skills": "DevOps, Docker", "experience": "5 years at CloudCo"},
+    {"id": 5, "name": "Eve", "skills": "Product strategy, Agile", "experience": "6 years at BigCorp"}
+  ],
+  "likes": {
+    "job_likes": {},
+    "job_dislikes": {},
+    "employee_likes": {},
+    "employee_dislikes": {}
+  },
+  "matches": []
+}

--- a/templates/candidate.html
+++ b/templates/candidate.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>Candidate Swipe</title>
 {% if job %}
-<p>Swiping for {{ job.title }} - {{ job.company }}</p>
+<p>Swiping for {{ job.title }} - {{ job.company }} | <a href="{{ url_for('matches') }}">Matches</a></p>
 {% endif %}
 <h2>{{ candidate.name }}</h2>
 <p><strong>Skills:</strong> {{ candidate.skills }}</p>

--- a/templates/done.html
+++ b/templates/done.html
@@ -2,3 +2,6 @@
 <title>Done</title>
 <p>No more {{ target }} to show.</p>
 <p><a href="{{ url_for('index') }}">Back to home</a></p>
+{% if job or employee %}
+<p><a href="{{ url_for('matches') }}">View Matches</a></p>
+{% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,3 +17,17 @@
   <label>Experience: <input type="text" name="experience" /></label><br />
   <button type="submit">Start Swiping Jobs</button>
 </form>
+
+<h2>Existing Jobs</h2>
+<ul>
+  {% for job in jobs %}
+  <li><a href="{{ url_for('login_job', job_id=job.id) }}">{{ job.title }} - {{ job.company }}</a></li>
+  {% endfor %}
+</ul>
+
+<h2>Existing Employees</h2>
+<ul>
+  {% for employee in employees %}
+  <li><a href="{{ url_for('login_employee', employee_id=employee.id) }}">{{ employee.name }}</a></li>
+  {% endfor %}
+</ul>

--- a/templates/job.html
+++ b/templates/job.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>Job Swipe</title>
 {% if employee %}
-<p>Swiping as {{ employee.name }}</p>
+<p>Swiping as {{ employee.name }} | <a href="{{ url_for('matches') }}">Matches</a></p>
 {% endif %}
 <h2>{{ job.title }} - {{ job.company }}</h2>
 <p>{{ job.description }}</p>

--- a/templates/matches.html
+++ b/templates/matches.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>Matches</title>
+<h1>Matches</h1>
+{% if my_job %}
+<p>Matches for {{ my_job.title }} - {{ my_job.company }}</p>
+<ul>
+  {% for emp in matches %}
+  <li><strong>{{ emp.name }}</strong> - {{ emp.skills }} ({{ emp.experience }})</li>
+  {% endfor %}
+</ul>
+{% elif my_employee %}
+<p>Matches for {{ my_employee.name }}</p>
+<ul>
+  {% for job in matches %}
+  <li><strong>{{ job.title }}</strong> - {{ job.company }}: {{ job.description }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+<p><a href="{{ url_for('index') }}">Back to home</a></p>


### PR DESCRIPTION
## Summary
- Persist jobs and employees in `data.json` so new accounts appear in future sessions
- Track likes, dislikes and mutual matches with links to review them
- List existing profiles on the home page for re-login and continued swiping

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc60af824832192ca112480a79e1c