### PR TITLE
Fix matches endpoint and handle empty match lists

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,7 +193,9 @@ def handle_candidate_action(action):
     return redirect(url_for("swipe_candidates"))
 
 
-@app.route("/matches")
+# Provide a consistent endpoint name so url_for('matches') works
+# even though there's a global 'matches' set in this module.
+@app.route("/matches", endpoint="matches")
 def matches_view():
     if "my_job_id" in session:
         job_id = session["my_job_id"]

--- a/templates/matches.html
+++ b/templates/matches.html
@@ -3,17 +3,25 @@
 <h1>Matches</h1>
 {% if my_job %}
 <p>Matches for {{ my_job.title }} - {{ my_job.company }}</p>
+{% if matches %}
 <ul>
   {% for emp in matches %}
   <li><strong>{{ emp.name }}</strong> - {{ emp.skills }} ({{ emp.experience }})</li>
   {% endfor %}
 </ul>
+{% else %}
+<p>No matches yet.</p>
+{% endif %}
 {% elif my_employee %}
 <p>Matches for {{ my_employee.name }}</p>
+{% if matches %}
 <ul>
   {% for job in matches %}
   <li><strong>{{ job.title }}</strong> - {{ job.company }}: {{ job.description }}</li>
   {% endfor %}
 </ul>
+{% else %}
+<p>No matches yet.</p>
+{% endif %}
 {% endif %}
 <p><a href="{{ url_for('index') }}">Back to home</a></p>


### PR DESCRIPTION
## Summary
- define explicit `matches` endpoint to resolve BuildError from templates
- show "No matches yet" when there are no matches for a job or employee

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc83bd63883218415a99c27b9297e