### PR TITLE
Show profile details during swiping

### DIFF
--- a/templates/candidate.html
+++ b/templates/candidate.html
@@ -1,7 +1,11 @@
 <!doctype html>
 <title>Candidate Swipe</title>
 {% if job %}
-<p>Swiping for {{ job.title }} - {{ job.company }} | <a href="{{ url_for('matches') }}">Matches</a></p>
+<p>
+  Swiping for {{ job.title }} - {{ job.company }}:
+  {{ job.description }} |
+  <a href="{{ url_for('matches') }}">Matches</a>
+</p>
 {% endif %}
 <h2>{{ candidate.name }}</h2>
 <p><strong>Skills:</strong> {{ candidate.skills }}</p>

--- a/templates/job.html
+++ b/templates/job.html
@@ -1,7 +1,11 @@
 <!doctype html>
 <title>Job Swipe</title>
 {% if employee %}
-<p>Swiping as {{ employee.name }} | <a href="{{ url_for('matches') }}">Matches</a></p>
+<p>
+  Swiping as {{ employee.name }} - {{ employee.skills }}
+  ({{ employee.experience }}) |
+  <a href="{{ url_for('matches') }}">Matches</a>
+</p>
 {% endif %}
 <h2>{{ job.title }} - {{ job.company }}</h2>
 <p>{{ job.description }}</p>


### PR DESCRIPTION
## Summary
- Show employee skills and experience while swiping jobs
- Display job description alongside title and company when swiping candidates

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dcc0c490483218c46a11a39cec692